### PR TITLE
storybookビルド時のエラー修正

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -1,5 +1,4 @@
 import type { StorybookConfig } from "@storybook/nextjs";
-import "../src/app/globals.css";
 
 const config: StorybookConfig = {
   stories: ["../src/**/*.mdx", "../src/**/*.stories.@(js|jsx|mjs|ts|tsx)"],


### PR DESCRIPTION
- #16 
  - `.storybook/main.ts`で`global.css`を読み込んでいたのが原因